### PR TITLE
Fix warning about usage of a constant called 'liggitt_filter_plugins_…

### DIFF
--- a/plugin-symlink.php
+++ b/plugin-symlink.php
@@ -19,4 +19,4 @@ function liggitt_filter_plugins_url($url) {
   return $newurl;
 }
 
-add_filter('plugins_url', liggitt_filter_plugins_url);
+add_filter('plugins_url', 'liggitt_filter_plugins_url');


### PR DESCRIPTION
Fix the warning: `Notice: Use of undefined constant liggitt_filter_plugins_url - assumed 'liggitt_filter_plugins_url'`
